### PR TITLE
Implemented patch for libpng 1.6.32beta06 vulnerability

### DIFF
--- a/PHOENIXEngine/PHOENIX/PX2Engine/Unity/ImageLibs/PNG/pngpread.c
+++ b/PHOENIXEngine/PHOENIX/PX2Engine/Unity/ImageLibs/PNG/pngpread.c
@@ -328,9 +328,23 @@ png_push_read_chunk(png_structp png_ptr, png_infop info_ptr)
       png_ptr->zstream.next_out = png_ptr->row_buf;
       return;
    }
+   else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
 
 #ifdef PNG_READ_gAMA_SUPPORTED
-   else if (png_ptr->chunk_name == png_gAMA)
+   if (png_ptr->chunk_name == png_gAMA)
    {
       if (png_ptr->push_length + 4 > png_ptr->buffer_size)
       {

--- a/PHOENIXEngine/PHOENIX/PX2Engine/Unity/ImageLibs/PNG/pngrutil.c
+++ b/PHOENIXEngine/PHOENIX/PX2Engine/Unity/ImageLibs/PNG/pngrutil.c
@@ -177,6 +177,22 @@ png_read_chunk_header(png_structp png_ptr)
    /* Check to see if chunk name is valid. */
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
+   /* Check for too-large chunk length */
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;
 #endif


### PR DESCRIPTION
A while back, [this patch (https://github.com/glennrp/libpng/commit)](https://github.com/glennrp/libpng/commit/347538efbdc21b8df684ebd92d37400b3ce85d55) was implemented for libpng. Your project is still vulnerable. I've simply added the 30 lines from the original patch.